### PR TITLE
feat(hub): visual polish for cards, header, and coins

### DIFF
--- a/hub/game_card.gd
+++ b/hub/game_card.gd
@@ -62,6 +62,11 @@ func _gui_input(event: InputEvent) -> void:
 				_launch_game()
 
 
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_MOUSE_EXIT:
+		_set_normal_style()
+
+
 func _set_pressed_style() -> void:
 	var pressed: StyleBoxFlat = _normal_style.duplicate() as StyleBoxFlat
 	pressed.bg_color = Color(0.22, 0.24, 0.3, 1.0)

--- a/hub/game_card.gd
+++ b/hub/game_card.gd
@@ -7,17 +7,36 @@ extends PanelContainer
 
 var _game_data: Dictionary = {}
 
+## Accent colors assigned per card index for visual variety.
+const ACCENT_COLORS: Array[Color] = [
+	Color(0.3, 0.55, 0.9, 1.0),   # blue
+	Color(0.85, 0.35, 0.4, 1.0),  # red
+	Color(0.3, 0.75, 0.5, 1.0),   # green
+	Color(0.9, 0.6, 0.2, 1.0),    # orange
+	Color(0.65, 0.4, 0.85, 1.0),  # purple
+	Color(0.2, 0.7, 0.8, 1.0),    # teal
+]
 
-func setup(game_data: Dictionary) -> void:
+var _normal_style: StyleBoxFlat
+var _accent_panel: PanelContainer
+
+
+func _ready() -> void:
+	mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
+	_normal_style = get_theme_stylebox("panel").duplicate() as StyleBoxFlat
+	_accent_panel = $VBoxContainer/AccentBar
+
+
+func setup(game_data: Dictionary, card_index: int = 0) -> void:
 	_game_data = game_data
 
 	if is_node_ready():
-		_apply_data()
+		_apply_data(card_index)
 	else:
-		ready.connect(_apply_data)
+		ready.connect(_apply_data.bind(card_index))
 
 
-func _apply_data() -> void:
+func _apply_data(card_index: int = 0) -> void:
 	game_name.text = _game_data.get("name", "Unknown")
 	description.text = _game_data.get("description", "")
 
@@ -25,12 +44,32 @@ func _apply_data() -> void:
 	if icon_path != "" and ResourceLoader.exists(icon_path):
 		icon.texture = load(icon_path)
 
+	# Apply accent color based on card index
+	var color: Color = ACCENT_COLORS[card_index % ACCENT_COLORS.size()]
+	var accent_style: StyleBoxFlat = _accent_panel.get_theme_stylebox("panel").duplicate() as StyleBoxFlat
+	accent_style.bg_color = color
+	_accent_panel.add_theme_stylebox_override("panel", accent_style)
+
 
 func _gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton:
 		var mb: InputEventMouseButton = event
-		if mb.button_index == MOUSE_BUTTON_LEFT and mb.pressed:
-			_launch_game()
+		if mb.button_index == MOUSE_BUTTON_LEFT:
+			if mb.pressed:
+				_set_pressed_style()
+			else:
+				_set_normal_style()
+				_launch_game()
+
+
+func _set_pressed_style() -> void:
+	var pressed: StyleBoxFlat = _normal_style.duplicate() as StyleBoxFlat
+	pressed.bg_color = Color(0.22, 0.24, 0.3, 1.0)
+	add_theme_stylebox_override("panel", pressed)
+
+
+func _set_normal_style() -> void:
+	add_theme_stylebox_override("panel", _normal_style)
 
 
 func _launch_game() -> void:

--- a/hub/game_card.tscn
+++ b/hub/game_card.tscn
@@ -1,32 +1,80 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene load_steps=4 format=3]
 
 [ext_resource type="Script" path="res://hub/game_card.gd" id="1"]
 
+[sub_resource type="StyleBoxFlat" id="card_style"]
+bg_color = Color(0.18, 0.2, 0.25, 1.0)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.35, 0.38, 0.45, 1.0)
+corner_radius_top_left = 12
+corner_radius_top_right = 12
+corner_radius_bottom_left = 12
+corner_radius_bottom_right = 12
+content_margin_left = 0.0
+content_margin_top = 0.0
+content_margin_right = 0.0
+content_margin_bottom = 12.0
+shadow_color = Color(0.0, 0.0, 0.0, 0.25)
+shadow_size = 4
+shadow_offset = Vector2(0, 2)
+
+[sub_resource type="StyleBoxFlat" id="accent_style"]
+bg_color = Color(0.3, 0.55, 0.9, 1.0)
+corner_radius_top_left = 12
+corner_radius_top_right = 12
+content_margin_left = 12.0
+content_margin_top = 12.0
+content_margin_right = 12.0
+content_margin_bottom = 12.0
+
 [node name="GameCard" type="PanelContainer"]
-custom_minimum_size = Vector2(0, 200)
+custom_minimum_size = Vector2(0, 220)
 layout_mode = 2
 size_flags_horizontal = 3
+theme_override_styles/panel = SubResource("card_style")
 script = ExtResource("1")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
 
-[node name="Icon" type="TextureRect" parent="VBoxContainer"]
+[node name="AccentBar" type="PanelContainer" parent="VBoxContainer"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 80)
+theme_override_styles/panel = SubResource("accent_style")
+
+[node name="Icon" type="TextureRect" parent="VBoxContainer/AccentBar"]
 unique_name_in_owner = true
 layout_mode = 2
-custom_minimum_size = Vector2(128, 128)
-expand_mode = 1
+custom_minimum_size = Vector2(56, 56)
+size_flags_horizontal = 4
+size_flags_vertical = 4
+expand_mode = 3
 stretch_mode = 5
 
-[node name="GameName" type="Label" parent="VBoxContainer"]
+[node name="ContentMargin" type="MarginContainer" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 12
+theme_override_constants/margin_right = 12
+theme_override_constants/margin_top = 8
+theme_override_constants/margin_bottom = 4
+
+[node name="Labels" type="VBoxContainer" parent="VBoxContainer/ContentMargin"]
+layout_mode = 2
+
+[node name="GameName" type="Label" parent="VBoxContainer/ContentMargin/Labels"]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_font_sizes/font_size = 20
+theme_override_font_sizes/font_size = 18
+theme_override_colors/font_color = Color(0.95, 0.95, 0.97, 1.0)
 horizontal_alignment = 1
 
-[node name="Description" type="Label" parent="VBoxContainer"]
+[node name="Description" type="Label" parent="VBoxContainer/ContentMargin/Labels"]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_font_sizes/font_size = 14
+theme_override_font_sizes/font_size = 13
+theme_override_colors/font_color = Color(0.65, 0.68, 0.75, 1.0)
 horizontal_alignment = 1
 autowrap_mode = 2

--- a/hub/hub.gd
+++ b/hub/hub.gd
@@ -1,7 +1,6 @@
 extends Control
 
 
-@onready var coin_display: Label = %CoinDisplay
 @onready var game_grid: GridContainer = %GameGrid
 
 var game_card_scene: PackedScene = preload("res://hub/game_card.tscn")
@@ -13,20 +12,15 @@ func _ready() -> void:
 	else:
 		GameRegistry.games_loaded.connect(_populate_games)
 
-	_update_coin_display()
-	CurrencyManager.coins_changed.connect(_update_coin_display)
-
 
 func _populate_games() -> void:
 	for child in game_grid.get_children():
 		child.queue_free()
 
 	var games: Array = GameRegistry.get_games()
+	var index: int = 0
 	for game_data: Dictionary in games:
 		var card: PanelContainer = game_card_scene.instantiate()
 		game_grid.add_child(card)
-		card.setup(game_data)
-
-
-func _update_coin_display(_new_balance: int = 0) -> void:
-	coin_display.text = "Coins: %d" % CurrencyManager.get_balance()
+		card.setup(game_data, index)
+		index += 1

--- a/hub/hub.tscn
+++ b/hub/hub.tscn
@@ -1,6 +1,16 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene load_steps=4 format=3]
 
 [ext_resource type="Script" path="res://hub/hub.gd" id="1"]
+[ext_resource type="PackedScene" path="res://shared/ui/coin_display.tscn" id="2"]
+
+[sub_resource type="StyleBoxFlat" id="header_style"]
+bg_color = Color(0.12, 0.13, 0.17, 1.0)
+content_margin_left = 20.0
+content_margin_top = 16.0
+content_margin_right = 20.0
+content_margin_bottom = 16.0
+border_width_bottom = 2
+border_color = Color(0.3, 0.55, 0.9, 0.6)
 
 [node name="Hub" type="Control"]
 layout_mode = 3
@@ -11,6 +21,15 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1")
 
+[node name="Background" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.1, 0.11, 0.14, 1.0)
+
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
 anchors_preset = 15
@@ -19,31 +38,45 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="HeaderBar" type="HBoxContainer" parent="VBoxContainer"]
+[node name="HeaderBar" type="PanelContainer" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_styles/panel = SubResource("header_style")
+
+[node name="HBox" type="HBoxContainer" parent="VBoxContainer/HeaderBar"]
 layout_mode = 2
 
-[node name="Title" type="Label" parent="VBoxContainer/HeaderBar"]
+[node name="Title" type="Label" parent="VBoxContainer/HeaderBar/HBox"]
 layout_mode = 2
-theme_override_font_sizes/font_size = 32
+theme_override_font_sizes/font_size = 28
+theme_override_colors/font_color = Color(0.95, 0.95, 0.97, 1.0)
 text = "Arcade"
 
-[node name="Spacer" type="Control" parent="VBoxContainer/HeaderBar"]
+[node name="Spacer" type="Control" parent="VBoxContainer/HeaderBar/HBox"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="CoinDisplay" type="Label" parent="VBoxContainer/HeaderBar"]
+[node name="CoinDisplay" parent="VBoxContainer/HeaderBar/HBox" instance=ExtResource("2")]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_font_sizes/font_size = 24
-text = "Coins: 0"
-horizontal_alignment = 2
+size_flags_vertical = 4
 
 [node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="GameGrid" type="GridContainer" parent="VBoxContainer/ScrollContainer"]
+[node name="GridMargin" type="MarginContainer" parent="VBoxContainer/ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_bottom = 16
+
+[node name="GameGrid" type="GridContainer" parent="VBoxContainer/ScrollContainer/GridMargin"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
+theme_override_constants/h_separation = 12
+theme_override_constants/v_separation = 12
 columns = 2

--- a/shared/ui/coin_display.gd
+++ b/shared/ui/coin_display.gd
@@ -1,5 +1,6 @@
 extends HBoxContainer
 ## Small HUD widget that displays the current coin balance.
+## Shows a yellow circle icon next to the number.
 ## Connects to CurrencyManager.coins_changed to stay in sync.
 
 @onready var balance_label: Label = $BalanceLabel

--- a/shared/ui/coin_display.tscn
+++ b/shared/ui/coin_display.tscn
@@ -4,12 +4,16 @@
 
 [node name="CoinDisplay" type="HBoxContainer"]
 script = ExtResource("1")
-theme_override_constants/separation = 8
+theme_override_constants/separation = 6
 
-[node name="IconLabel" type="Label" parent="."]
+[node name="CoinIcon" type="Label" parent="."]
 layout_mode = 2
-text = "🪙"
+theme_override_font_sizes/font_size = 18
+theme_override_colors/font_color = Color(1.0, 0.85, 0.2, 1.0)
+text = "\u2b24"
 
 [node name="BalanceLabel" type="Label" parent="."]
 layout_mode = 2
+theme_override_font_sizes/font_size = 22
+theme_override_colors/font_color = Color(1.0, 0.85, 0.2, 1.0)
 text = "0"


### PR DESCRIPTION
## Summary
- **Game cards (#7):** Styled with `StyleBoxFlat` — dark background, subtle border, 12px rounded corners, drop shadow, and a colored accent bar at the top that cycles through 6 colors for visual variety. Cards show press feedback and a pointer cursor for tappability.
- **Header bar (#8):** Wrapped in a `PanelContainer` with a dark styled background and a blue accent border along the bottom. Title "Arcade" on the left, coin display right-aligned. Added a dark `ColorRect` background to the entire hub.
- **Coin icon (#9):** Replaced emoji with a yellow filled circle (U+2B24) and styled both the icon and balance text in gold. The `coin_display.tscn` scene is now instanced directly in the hub header instead of using a raw Label.

Closes #7, closes #8, closes #9

## Test plan
- [ ] Launch the hub scene and verify cards render with rounded borders, shadow, and colored accent bars
- [ ] Verify each card in the grid gets a different accent color
- [ ] Confirm the header bar shows "Arcade" on the left and a yellow coin indicator on the right
- [ ] Verify a blue accent line separates the header from the game grid
- [ ] Tap a card and confirm the press darkening effect appears
- [ ] Check that the coin balance updates when coins change
- [ ] Verify portrait mobile layout looks correct at 720x1280

🤖 Generated with [Claude Code](https://claude.com/claude-code)