### PR TITLE
feat(shared): add shared game over screen with restart

### DIFF
--- a/games/dodge/game.gd
+++ b/games/dodge/game.gd
@@ -14,6 +14,7 @@ var touch_target_x: float = -1.0
 @onready var score_label: Label = $ScoreLabel
 @onready var spawn_timer: Timer = $SpawnTimer
 @onready var pause_menu: CanvasLayer = $PauseMenu
+@onready var game_over_screen: CanvasLayer = $GameOverScreen
 
 
 func _ready() -> void:
@@ -122,20 +123,7 @@ func _game_over() -> void:
 	spawn_timer.stop()
 
 	var coins_earned: int = award_coins()
-
-	var vp: Vector2 = get_viewport_rect().size
-	var label_size: Vector2 = Vector2(500, 200)
-	var game_over_label: Label = Label.new()
-	game_over_label.text = "Game Over!\nScore: %d\nCoins: +%d" % [int(time_played), coins_earned]
-	game_over_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	game_over_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
-	game_over_label.add_theme_font_size_override("font_size", 48)
-	game_over_label.size = label_size
-	game_over_label.position = (vp - label_size) / 2.0
-	add_child(game_over_label)
-
-	await get_tree().create_timer(2.0).timeout
-	SceneTransition.go_to_hub()
+	game_over_screen.show_game_over("Game Over!", "Score: %d" % int(time_played), coins_earned)
 
 
 func _on_pause_pressed() -> void:

--- a/games/dodge/game.tscn
+++ b/games/dodge/game.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=3]
+[gd_scene load_steps=5 format=3]
 
 [ext_resource type="Script" path="res://games/dodge/game.gd" id="1"]
 [ext_resource type="PackedScene" path="res://shared/ui/pause_menu.tscn" id="2"]
+[ext_resource type="PackedScene" path="res://shared/ui/game_over_screen.tscn" id="3"]
 
 [sub_resource type="RectangleShape2D" id="1"]
 size = Vector2(60, 60)
@@ -56,6 +57,8 @@ wait_time = 1.0
 autostart = true
 
 [node name="PauseMenu" parent="." instance=ExtResource("2")]
+
+[node name="GameOverScreen" parent="." instance=ExtResource("3")]
 
 [connection signal="pressed" from="PauseButton" to="." method="_on_pause_pressed"]
 [connection signal="timeout" from="SpawnTimer" to="." method="_on_spawn_timer_timeout"]

--- a/games/snake/game.gd
+++ b/games/snake/game.gd
@@ -21,6 +21,7 @@ var _effects: SnakeEffects
 
 @onready var camera: Camera2D = $Camera2D
 @onready var pause_menu: CanvasLayer = $PauseMenu
+@onready var game_over_screen: CanvasLayer = $GameOverScreen
 @onready var score_label: Label = $UI/ScoreLabel
 
 
@@ -206,19 +207,7 @@ func _end_game(cleared: bool) -> void:
 		CurrencyManager.add_coins(coins_earned)
 
 	var end_text: String = "Map Cleared!" if cleared else "Game Over!"
-	var vp: Vector2 = get_viewport_rect().size
-	var label_size: Vector2 = Vector2(500, 200)
-	var end_label: Label = Label.new()
-	end_label.text = "%s\nScore: %d\nCoins: +%d" % [end_text, snake.segments_eaten, coins_earned]
-	end_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	end_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
-	end_label.add_theme_font_size_override("font_size", 48)
-	end_label.size = label_size
-	end_label.position = (vp - label_size) / 2.0
-	$UI.add_child(end_label)
-
-	await get_tree().create_timer(2.5).timeout
-	SceneTransition.go_to_hub()
+	game_over_screen.show_game_over(end_text, "Score: %d" % snake.segments_eaten, coins_earned)
 
 
 func _on_direction_changed(dir: Vector2) -> void:

--- a/games/snake/game.tscn
+++ b/games/snake/game.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3]
+[gd_scene load_steps=5 format=3]
 
 [ext_resource type="Script" path="res://games/snake/game.gd" id="1"]
 [ext_resource type="PackedScene" path="res://shared/ui/pause_menu.tscn" id="2"]
 [ext_resource type="Script" path="res://games/snake/joystick.gd" id="3"]
+[ext_resource type="PackedScene" path="res://shared/ui/game_over_screen.tscn" id="4"]
 
 [node name="Game" type="Node2D"]
 script = ExtResource("1")
@@ -38,5 +39,7 @@ text = "Pause"
 script = ExtResource("3")
 
 [node name="PauseMenu" parent="." instance=ExtResource("2")]
+
+[node name="GameOverScreen" parent="." instance=ExtResource("4")]
 
 [connection signal="pressed" from="UI/PauseButton" to="." method="_on_pause_pressed"]

--- a/shared/ui/game_over_screen.gd
+++ b/shared/ui/game_over_screen.gd
@@ -23,6 +23,7 @@ func show_game_over(title: String, score_text: String, coins: int) -> void:
 	title_label.text = title
 	score_label.text = score_text
 	coins_label.text = "Coins: +%d" % coins
+	overlay.modulate.a = 0.0
 	overlay.visible = true
 
 	# Animate overlay fade in and panel slide down.

--- a/shared/ui/game_over_screen.gd
+++ b/shared/ui/game_over_screen.gd
@@ -1,0 +1,49 @@
+extends CanvasLayer
+## Shared game over screen overlay.
+## Shows title, score, coins earned, and play again / quit buttons.
+## Usage: call show_game_over("Game Over!", "Score: 42", 12)
+
+@onready var overlay: ColorRect = $Overlay
+@onready var panel: PanelContainer = $Overlay/Panel
+@onready var title_label: Label = $Overlay/Panel/VBoxContainer/TitleLabel
+@onready var score_label: Label = $Overlay/Panel/VBoxContainer/ScoreLabel
+@onready var coins_label: Label = $Overlay/Panel/VBoxContainer/CoinsLabel
+@onready var play_again_button: Button = $Overlay/Panel/VBoxContainer/PlayAgainButton
+@onready var hub_button: Button = $Overlay/Panel/VBoxContainer/HubButton
+
+
+func _ready() -> void:
+	overlay.visible = false
+	overlay.modulate.a = 0.0
+	panel.pivot_offset = panel.size / 2.0
+
+
+func show_game_over(title: String, score_text: String, coins: int) -> void:
+	get_tree().paused = true
+	title_label.text = title
+	score_label.text = score_text
+	coins_label.text = "Coins: +%d" % coins
+	overlay.visible = true
+
+	# Animate overlay fade in and panel slide down.
+	panel.position.y -= 60.0
+	var start_y: float = panel.position.y
+	var target_y: float = start_y + 60.0
+
+	var tween: Tween = create_tween()
+	tween.set_pause_mode(Tween.TWEEN_PAUSE_PROCESS)
+	tween.set_parallel(true)
+	tween.tween_property(overlay, "modulate:a", 1.0, 0.4).set_ease(Tween.EASE_OUT)
+	tween.tween_property(panel, "position:y", target_y, 0.5).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BACK)
+
+
+func _on_play_again_pressed() -> void:
+	get_tree().paused = false
+	overlay.visible = false
+	get_tree().reload_current_scene()
+
+
+func _on_hub_pressed() -> void:
+	get_tree().paused = false
+	overlay.visible = false
+	SceneTransition.go_to_hub()

--- a/shared/ui/game_over_screen.tscn
+++ b/shared/ui/game_over_screen.tscn
@@ -1,0 +1,65 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://shared/ui/game_over_screen.gd" id="1"]
+
+[node name="GameOverScreen" type="CanvasLayer"]
+layer = 90
+process_mode = 3
+script = ExtResource("1")
+
+[node name="Overlay" type="ColorRect" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 0.6)
+visible = false
+
+[node name="Panel" type="PanelContainer" parent="Overlay"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -160.0
+offset_top = -140.0
+offset_right = 160.0
+offset_bottom = 140.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Overlay/Panel"]
+layout_mode = 2
+theme_override_constants/separation = 16
+alignment = 1
+
+[node name="TitleLabel" type="Label" parent="Overlay/Panel/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Game Over!"
+horizontal_alignment = 1
+
+[node name="ScoreLabel" type="Label" parent="Overlay/Panel/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 24
+text = "Score: 0"
+horizontal_alignment = 1
+
+[node name="CoinsLabel" type="Label" parent="Overlay/Panel/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 20
+text = "Coins: +0"
+horizontal_alignment = 1
+
+[node name="PlayAgainButton" type="Button" parent="Overlay/Panel/VBoxContainer"]
+layout_mode = 2
+text = "Play Again"
+
+[node name="HubButton" type="Button" parent="Overlay/Panel/VBoxContainer"]
+layout_mode = 2
+text = "Back to Hub"
+
+[connection signal="pressed" from="Overlay/Panel/VBoxContainer/PlayAgainButton" to="." method="_on_play_again_pressed"]
+[connection signal="pressed" from="Overlay/Panel/VBoxContainer/HubButton" to="." method="_on_hub_pressed"]


### PR DESCRIPTION
## Summary
- Add `shared/ui/game_over_screen.tscn` + `.gd` — a reusable CanvasLayer overlay (layer 90, process_mode ALWAYS) with title, score, coins earned, "Play Again" and "Back to Hub" buttons
- Animate in with overlay fade + panel slide-down using tweens
- Pause the game tree while showing (matching pause menu pattern)
- Replace inline Label creation + `await timer` + `go_to_hub()` in both dodge and snake games with a single `game_over_screen.show_game_over()` call

Closes #4

## Test plan
- [ ] Launch dodge game, get hit by a block — game over screen appears with fade animation, correct score and coins
- [ ] Press "Play Again" — dodge game restarts fresh
- [ ] Press "Back to Hub" — returns to hub via SceneTransition
- [ ] Launch snake game, collide with wall/self — game over screen shows "Game Over!" with score
- [ ] Launch snake game, eat all food — game over screen shows "Map Cleared!" with 2x coin multiplier
- [ ] Verify game is paused while overlay is visible (blocks don't fall, snake doesn't move)
- [ ] Verify pause button still works during gameplay (before game over)

🤖 Generated with [Claude Code](https://claude.com/claude-code)