### PR TITLE
Add live game previews to hub cards

### DIFF
--- a/games/dodge/preview.gd
+++ b/games/dodge/preview.gd
@@ -1,0 +1,63 @@
+extends Node2D
+## Scripted demo of the dodge game for hub card preview.
+
+const PREVIEW_SIZE: Vector2 = Vector2(200, 200)
+const PLAYER_SIZE: Vector2 = Vector2(20, 20)
+const BLOCK_SIZE: Vector2 = Vector2(20, 20)
+const PLAYER_SPEED: float = 80.0
+const FALL_SPEED: float = 120.0
+const SPAWN_INTERVAL: float = 0.8
+
+var _player_pos: Vector2
+var _player_dir: float = 1.0
+var _blocks: Array[Vector2] = []
+var _spawn_timer: float = 0.0
+
+
+func _ready() -> void:
+	_player_pos = Vector2(PREVIEW_SIZE.x / 2.0, PREVIEW_SIZE.y - 30.0)
+
+
+func _process(delta: float) -> void:
+	_move_player(delta)
+	_update_blocks(delta)
+	_spawn_timer += delta
+	if _spawn_timer >= SPAWN_INTERVAL:
+		_spawn_timer = 0.0
+		_spawn_block()
+	queue_redraw()
+
+
+func _move_player(delta: float) -> void:
+	for block_pos: Vector2 in _blocks:
+		if block_pos.y > PREVIEW_SIZE.y - 60.0 and block_pos.y < PREVIEW_SIZE.y - 10.0:
+			if absf(block_pos.x - _player_pos.x) < 25.0:
+				_player_dir = signf(_player_pos.x - block_pos.x)
+				if _player_dir == 0.0:
+					_player_dir = 1.0
+	if _player_pos.x < 20.0:
+		_player_dir = 1.0
+	elif _player_pos.x > PREVIEW_SIZE.x - 20.0:
+		_player_dir = -1.0
+	_player_pos.x += _player_dir * PLAYER_SPEED * delta
+
+
+func _spawn_block() -> void:
+	var x: float = randf_range(BLOCK_SIZE.x, PREVIEW_SIZE.x - BLOCK_SIZE.x)
+	_blocks.append(Vector2(x, -BLOCK_SIZE.y))
+
+
+func _update_blocks(delta: float) -> void:
+	var i: int = _blocks.size() - 1
+	while i >= 0:
+		_blocks[i].y += FALL_SPEED * delta
+		if _blocks[i].y > PREVIEW_SIZE.y + 20.0:
+			_blocks.remove_at(i)
+		i -= 1
+
+
+func _draw() -> void:
+	draw_rect(Rect2(Vector2.ZERO, PREVIEW_SIZE), Color(0.1, 0.1, 0.15))
+	draw_rect(Rect2(_player_pos - PLAYER_SIZE / 2.0, PLAYER_SIZE), Color(0.2, 0.7, 1.0))
+	for block_pos: Vector2 in _blocks:
+		draw_rect(Rect2(block_pos - BLOCK_SIZE / 2.0, BLOCK_SIZE), Color(1.0, 0.3, 0.3))

--- a/games/dodge/preview.gd
+++ b/games/dodge/preview.gd
@@ -57,7 +57,7 @@ func _update_blocks(delta: float) -> void:
 
 
 func _draw() -> void:
-	draw_rect(Rect2(Vector2.ZERO, PREVIEW_SIZE), Color(0.1, 0.1, 0.15))
+	draw_rect(Rect2(Vector2.ZERO, PREVIEW_SIZE), Color(0.12, 0.14, 0.18))
 	draw_rect(Rect2(_player_pos - PLAYER_SIZE / 2.0, PLAYER_SIZE), Color(0.2, 0.7, 1.0))
 	for block_pos: Vector2 in _blocks:
 		draw_rect(Rect2(block_pos - BLOCK_SIZE / 2.0, BLOCK_SIZE), Color(1.0, 0.3, 0.3))

--- a/games/dodge/preview.gd
+++ b/games/dodge/preview.gd
@@ -1,7 +1,7 @@
 extends Node2D
 ## Scripted demo of the dodge game for hub card preview.
 
-const PREVIEW_SIZE: Vector2 = Vector2(200, 200)
+const PREVIEW_SIZE: Vector2 = Vector2(320, 200)
 const PLAYER_SIZE: Vector2 = Vector2(20, 20)
 const BLOCK_SIZE: Vector2 = Vector2(20, 20)
 const PLAYER_SPEED: float = 80.0

--- a/games/dodge/preview.tscn
+++ b/games/dodge/preview.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://games/dodge/preview.gd" id="1"]
+
+[node name="Preview" type="Node2D"]
+script = ExtResource("1")

--- a/games/snake/preview.gd
+++ b/games/snake/preview.gd
@@ -1,7 +1,7 @@
 extends Node2D
 ## Scripted demo of the snake game for hub card preview.
 
-const PREVIEW_MAP: Vector2 = Vector2(400, 400)
+const PREVIEW_MAP: Vector2 = Vector2(200, 200)
 const DIRECTION_CHANGE_INTERVAL: float = 1.5
 
 var _snake: Snake
@@ -20,7 +20,7 @@ func _ready() -> void:
 	_snake.position = PREVIEW_MAP / 2.0
 	_snake.direction = _directions[0]
 	add_child(_snake)
-	_snake.grow(5)
+	_snake.grow(3)
 
 
 func _process(delta: float) -> void:
@@ -32,7 +32,7 @@ func _process(delta: float) -> void:
 
 	# Bounce off walls — set both current and target direction immediately
 	# to avoid the smooth turning letting the snake escape.
-	var margin: float = 30.0
+	var margin: float = 15.0
 	var dir: Vector2 = _snake.direction
 	var bounced: bool = false
 	if _snake.position.x < margin:
@@ -53,7 +53,7 @@ func _process(delta: float) -> void:
 		_snake._target_direction = dir
 
 	_food_timer += delta
-	if _food_timer >= 2.0 and _snake.segments_eaten < 30:
+	if _food_timer >= 2.0 and _snake.segments_eaten < 15:
 		_food_timer = 0.0
 		_snake.grow(1)
 

--- a/games/snake/preview.gd
+++ b/games/snake/preview.gd
@@ -59,5 +59,4 @@ func _process(delta: float) -> void:
 
 
 func _draw() -> void:
-	draw_rect(Rect2(Vector2.ZERO, PREVIEW_MAP), Color(0.08, 0.08, 0.12))
-	draw_rect(Rect2(Vector2.ZERO, PREVIEW_MAP), Color(0.3, 0.3, 0.4), false, 2.0)
+	draw_rect(Rect2(Vector2.ZERO, PREVIEW_MAP), Color(0.12, 0.14, 0.18))

--- a/games/snake/preview.gd
+++ b/games/snake/preview.gd
@@ -1,7 +1,7 @@
 extends Node2D
 ## Scripted demo of the snake game for hub card preview.
 
-const PREVIEW_MAP: Vector2 = Vector2(200, 200)
+const PREVIEW_MAP: Vector2 = Vector2(320, 200)
 const DIRECTION_CHANGE_INTERVAL: float = 1.5
 
 var _snake: Snake

--- a/hub/game_card.gd
+++ b/hub/game_card.gd
@@ -4,8 +4,11 @@ extends PanelContainer
 @onready var icon: TextureRect = %Icon
 @onready var game_name: Label = %GameName
 @onready var description: Label = %Description
+@onready var _preview_container: SubViewportContainer = %PreviewContainer
+@onready var _preview_viewport: SubViewport = %PreviewViewport
 
 var _game_data: Dictionary = {}
+var _scroll_parent: ScrollContainer = null
 
 ## Accent colors assigned per card index for visual variety.
 const ACCENT_COLORS: Array[Color] = [
@@ -25,6 +28,13 @@ func _ready() -> void:
 	mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
 	_normal_style = get_theme_stylebox("panel").duplicate() as StyleBoxFlat
 	_accent_panel = $VBoxContainer/AccentBar
+	# Cache scroll parent for visibility-based preview pausing.
+	var parent: Node = get_parent()
+	while parent != null:
+		if parent is ScrollContainer:
+			_scroll_parent = parent as ScrollContainer
+			break
+		parent = parent.get_parent()
 
 
 func setup(game_data: Dictionary, card_index: int = 0) -> void:
@@ -40,15 +50,38 @@ func _apply_data(card_index: int = 0) -> void:
 	game_name.text = _game_data.get("name", "Unknown")
 	description.text = _game_data.get("description", "")
 
-	var icon_path: String = _game_data.get("icon", "")
-	if icon_path != "" and ResourceLoader.exists(icon_path):
-		icon.texture = load(icon_path)
-
-	# Apply accent color based on card index
+	# Apply accent color based on card index.
 	var color: Color = ACCENT_COLORS[card_index % ACCENT_COLORS.size()]
 	var accent_style: StyleBoxFlat = _accent_panel.get_theme_stylebox("panel").duplicate() as StyleBoxFlat
 	accent_style.bg_color = color
 	_accent_panel.add_theme_stylebox_override("panel", accent_style)
+
+	# Try to load a live preview for this game.
+	var game_id: String = _game_data.get("id", "")
+	var preview_path: String = "res://games/%s/preview.tscn" % game_id
+	if game_id != "" and ResourceLoader.exists(preview_path):
+		var preview_scene: PackedScene = load(preview_path)
+		var preview_instance: Node = preview_scene.instantiate()
+		_preview_viewport.add_child(preview_instance)
+		_preview_container.visible = true
+		icon.visible = false
+	else:
+		_preview_container.visible = false
+		icon.visible = true
+		var icon_path: String = _game_data.get("icon", "")
+		if icon_path != "" and ResourceLoader.exists(icon_path):
+			icon.texture = load(icon_path)
+
+
+func _process(_delta: float) -> void:
+	if _preview_viewport == null or not _preview_container.visible:
+		return
+	var visible_in_scroll: bool = true
+	if _scroll_parent != null:
+		visible_in_scroll = get_global_rect().intersects(_scroll_parent.get_global_rect())
+	var target_mode: SubViewport.UpdateMode = SubViewport.UPDATE_ALWAYS if visible_in_scroll else SubViewport.UPDATE_DISABLED
+	if _preview_viewport.render_target_update_mode != target_mode:
+		_preview_viewport.render_target_update_mode = target_mode
 
 
 func _gui_input(event: InputEvent) -> void:

--- a/hub/game_card.gd
+++ b/hub/game_card.gd
@@ -93,61 +93,44 @@ func _process(_delta: float) -> void:
 func _draw() -> void:
 	if not _preview_container.visible or _accent_panel == null:
 		return
-	# Draw neon frame around the preview area with tapered triangle endpoints.
 	var rect: Rect2 = _accent_panel.get_rect()
 	var c: Color = _accent_color
-	var glow: Color = Color(c, 0.3)
-	var line_w: float = 2.5
-	var taper: float = 10.0  # Triangle taper length.
-	var inset: float = 2.0
+	var glow: Color = Color(c, 0.25)
+	var line_w: float = 3.0
+	var taper: float = 14.0
+	var corner: float = 14.0  # Stay inside corner radius.
 
-	# Top line — full width, tapers into triangles at each end.
-	var top_y: float = rect.position.y + inset
-	draw_line(Vector2(rect.position.x + taper, top_y), Vector2(rect.end.x - taper, top_y), c, line_w, true)
-	# Left taper triangle.
-	draw_colored_polygon(PackedVector2Array([
-		Vector2(rect.position.x + taper, top_y - line_w * 0.5),
-		Vector2(rect.position.x + taper, top_y + line_w * 0.5),
-		Vector2(rect.position.x, top_y),
-	]), c)
-	# Right taper triangle.
-	draw_colored_polygon(PackedVector2Array([
-		Vector2(rect.end.x - taper, top_y - line_w * 0.5),
-		Vector2(rect.end.x - taper, top_y + line_w * 0.5),
-		Vector2(rect.end.x, top_y),
-	]), c)
-	# Glow behind top line.
-	draw_line(Vector2(rect.position.x + taper, top_y), Vector2(rect.end.x - taper, top_y), glow, line_w + 4.0, true)
+	# Top line.
+	var top_y: float = rect.position.y + corner
+	draw_line(Vector2(rect.position.x + corner + taper, top_y), Vector2(rect.end.x - corner - taper, top_y), c, line_w, true)
+	draw_line(Vector2(rect.position.x + corner + taper, top_y), Vector2(rect.end.x - corner - taper, top_y), glow, line_w + 6.0, true)
+	_draw_taper(Vector2(rect.position.x + corner + taper, top_y), Vector2(rect.position.x + corner, top_y), line_w, c)
+	_draw_taper(Vector2(rect.end.x - corner - taper, top_y), Vector2(rect.end.x - corner, top_y), line_w, c)
 
-	# Left line — from below top taper to bottom, tapers at both ends.
-	var left_x: float = rect.position.x + inset
-	draw_line(Vector2(left_x, rect.position.y + taper), Vector2(left_x, rect.end.y - taper), c, line_w, true)
-	draw_colored_polygon(PackedVector2Array([
-		Vector2(left_x - line_w * 0.5, rect.position.y + taper),
-		Vector2(left_x + line_w * 0.5, rect.position.y + taper),
-		Vector2(left_x, rect.position.y),
-	]), c)
-	draw_colored_polygon(PackedVector2Array([
-		Vector2(left_x - line_w * 0.5, rect.end.y - taper),
-		Vector2(left_x + line_w * 0.5, rect.end.y - taper),
-		Vector2(left_x, rect.end.y),
-	]), c)
-	draw_line(Vector2(left_x, rect.position.y + taper), Vector2(left_x, rect.end.y - taper), glow, line_w + 4.0, true)
+	# Left line.
+	var left_x: float = rect.position.x + corner
+	draw_line(Vector2(left_x, rect.position.y + corner + taper), Vector2(left_x, rect.end.y - taper), c, line_w, true)
+	draw_line(Vector2(left_x, rect.position.y + corner + taper), Vector2(left_x, rect.end.y - taper), glow, line_w + 6.0, true)
+	_draw_taper(Vector2(left_x, rect.position.y + corner + taper), Vector2(left_x, rect.position.y + corner), line_w, c)
+	_draw_taper(Vector2(left_x, rect.end.y - taper), Vector2(left_x, rect.end.y), line_w, c)
 
-	# Right line — same as left.
-	var right_x: float = rect.end.x - inset
-	draw_line(Vector2(right_x, rect.position.y + taper), Vector2(right_x, rect.end.y - taper), c, line_w, true)
+	# Right line.
+	var right_x: float = rect.end.x - corner
+	draw_line(Vector2(right_x, rect.position.y + corner + taper), Vector2(right_x, rect.end.y - taper), c, line_w, true)
+	draw_line(Vector2(right_x, rect.position.y + corner + taper), Vector2(right_x, rect.end.y - taper), glow, line_w + 6.0, true)
+	_draw_taper(Vector2(right_x, rect.position.y + corner + taper), Vector2(right_x, rect.position.y + corner), line_w, c)
+	_draw_taper(Vector2(right_x, rect.end.y - taper), Vector2(right_x, rect.end.y), line_w, c)
+
+
+func _draw_taper(line_end: Vector2, point: Vector2, width: float, color: Color) -> void:
+	## Draw a triangle that tapers from line_end (full width) to point (zero width).
+	var dir: Vector2 = (point - line_end).normalized()
+	var perp: Vector2 = Vector2(-dir.y, dir.x)
 	draw_colored_polygon(PackedVector2Array([
-		Vector2(right_x - line_w * 0.5, rect.position.y + taper),
-		Vector2(right_x + line_w * 0.5, rect.position.y + taper),
-		Vector2(right_x, rect.position.y),
-	]), c)
-	draw_colored_polygon(PackedVector2Array([
-		Vector2(right_x - line_w * 0.5, rect.end.y - taper),
-		Vector2(right_x + line_w * 0.5, rect.end.y - taper),
-		Vector2(right_x, rect.end.y),
-	]), c)
-	draw_line(Vector2(right_x, rect.position.y + taper), Vector2(right_x, rect.end.y - taper), glow, line_w + 4.0, true)
+		line_end + perp * width * 0.5,
+		line_end - perp * width * 0.5,
+		point,
+	]), color)
 
 
 func _gui_input(event: InputEvent) -> void:

--- a/hub/game_card.gd
+++ b/hub/game_card.gd
@@ -50,10 +50,10 @@ func _apply_data(card_index: int = 0) -> void:
 	game_name.text = _game_data.get("name", "Unknown")
 	description.text = _game_data.get("description", "")
 
-	# Apply accent color based on card index.
+	# Apply accent color as border on preview area.
 	var color: Color = ACCENT_COLORS[card_index % ACCENT_COLORS.size()]
 	var accent_style: StyleBoxFlat = _accent_panel.get_theme_stylebox("panel").duplicate() as StyleBoxFlat
-	accent_style.bg_color = color
+	accent_style.border_color = color
 	_accent_panel.add_theme_stylebox_override("panel", accent_style)
 
 	# Try to load a live preview for this game.

--- a/hub/game_card.gd
+++ b/hub/game_card.gd
@@ -22,6 +22,7 @@ const ACCENT_COLORS: Array[Color] = [
 
 var _normal_style: StyleBoxFlat
 var _accent_panel: PanelContainer
+var _accent_color: Color = Color(0.3, 0.55, 0.9)
 
 
 func _ready() -> void:
@@ -50,11 +51,16 @@ func _apply_data(card_index: int = 0) -> void:
 	game_name.text = _game_data.get("name", "Unknown")
 	description.text = _game_data.get("description", "")
 
-	# Apply accent color as border on preview area.
-	var color: Color = ACCENT_COLORS[card_index % ACCENT_COLORS.size()]
+	# Set accent color for neon frame drawing.
+	_accent_color = ACCENT_COLORS[card_index % ACCENT_COLORS.size()]
+	# Remove border from style — we draw it ourselves.
 	var accent_style: StyleBoxFlat = _accent_panel.get_theme_stylebox("panel").duplicate() as StyleBoxFlat
-	accent_style.border_color = color
+	accent_style.border_width_left = 0
+	accent_style.border_width_top = 0
+	accent_style.border_width_right = 0
+	accent_style.border_width_bottom = 0
 	_accent_panel.add_theme_stylebox_override("panel", accent_style)
+	queue_redraw()
 
 	# Try to load a live preview for this game.
 	var game_id: String = _game_data.get("id", "")
@@ -82,6 +88,66 @@ func _process(_delta: float) -> void:
 	var target_mode: SubViewport.UpdateMode = SubViewport.UPDATE_ALWAYS if visible_in_scroll else SubViewport.UPDATE_DISABLED
 	if _preview_viewport.render_target_update_mode != target_mode:
 		_preview_viewport.render_target_update_mode = target_mode
+
+
+func _draw() -> void:
+	if not _preview_container.visible or _accent_panel == null:
+		return
+	# Draw neon frame around the preview area with tapered triangle endpoints.
+	var rect: Rect2 = _accent_panel.get_rect()
+	var c: Color = _accent_color
+	var glow: Color = Color(c, 0.3)
+	var line_w: float = 2.5
+	var taper: float = 10.0  # Triangle taper length.
+	var inset: float = 2.0
+
+	# Top line — full width, tapers into triangles at each end.
+	var top_y: float = rect.position.y + inset
+	draw_line(Vector2(rect.position.x + taper, top_y), Vector2(rect.end.x - taper, top_y), c, line_w, true)
+	# Left taper triangle.
+	draw_colored_polygon(PackedVector2Array([
+		Vector2(rect.position.x + taper, top_y - line_w * 0.5),
+		Vector2(rect.position.x + taper, top_y + line_w * 0.5),
+		Vector2(rect.position.x, top_y),
+	]), c)
+	# Right taper triangle.
+	draw_colored_polygon(PackedVector2Array([
+		Vector2(rect.end.x - taper, top_y - line_w * 0.5),
+		Vector2(rect.end.x - taper, top_y + line_w * 0.5),
+		Vector2(rect.end.x, top_y),
+	]), c)
+	# Glow behind top line.
+	draw_line(Vector2(rect.position.x + taper, top_y), Vector2(rect.end.x - taper, top_y), glow, line_w + 4.0, true)
+
+	# Left line — from below top taper to bottom, tapers at both ends.
+	var left_x: float = rect.position.x + inset
+	draw_line(Vector2(left_x, rect.position.y + taper), Vector2(left_x, rect.end.y - taper), c, line_w, true)
+	draw_colored_polygon(PackedVector2Array([
+		Vector2(left_x - line_w * 0.5, rect.position.y + taper),
+		Vector2(left_x + line_w * 0.5, rect.position.y + taper),
+		Vector2(left_x, rect.position.y),
+	]), c)
+	draw_colored_polygon(PackedVector2Array([
+		Vector2(left_x - line_w * 0.5, rect.end.y - taper),
+		Vector2(left_x + line_w * 0.5, rect.end.y - taper),
+		Vector2(left_x, rect.end.y),
+	]), c)
+	draw_line(Vector2(left_x, rect.position.y + taper), Vector2(left_x, rect.end.y - taper), glow, line_w + 4.0, true)
+
+	# Right line — same as left.
+	var right_x: float = rect.end.x - inset
+	draw_line(Vector2(right_x, rect.position.y + taper), Vector2(right_x, rect.end.y - taper), c, line_w, true)
+	draw_colored_polygon(PackedVector2Array([
+		Vector2(right_x - line_w * 0.5, rect.position.y + taper),
+		Vector2(right_x + line_w * 0.5, rect.position.y + taper),
+		Vector2(right_x, rect.position.y),
+	]), c)
+	draw_colored_polygon(PackedVector2Array([
+		Vector2(right_x - line_w * 0.5, rect.end.y - taper),
+		Vector2(right_x + line_w * 0.5, rect.end.y - taper),
+		Vector2(right_x, rect.end.y),
+	]), c)
+	draw_line(Vector2(right_x, rect.position.y + taper), Vector2(right_x, rect.end.y - taper), glow, line_w + 4.0, true)
 
 
 func _gui_input(event: InputEvent) -> void:

--- a/hub/game_card.tscn
+++ b/hub/game_card.tscn
@@ -23,11 +23,6 @@ shadow_offset = Vector2(0, 2)
 
 [sub_resource type="StyleBoxFlat" id="accent_style"]
 bg_color = Color(0.12, 0.14, 0.18, 1.0)
-border_width_left = 3
-border_width_top = 3
-border_width_right = 3
-border_width_bottom = 0
-border_color = Color(0.3, 0.55, 0.9, 1.0)
 corner_radius_top_left = 12
 corner_radius_top_right = 12
 content_margin_left = 3.0

--- a/hub/game_card.tscn
+++ b/hub/game_card.tscn
@@ -25,13 +25,13 @@ shadow_offset = Vector2(0, 2)
 bg_color = Color(0.3, 0.55, 0.9, 1.0)
 corner_radius_top_left = 12
 corner_radius_top_right = 12
-content_margin_left = 12.0
-content_margin_top = 12.0
-content_margin_right = 12.0
-content_margin_bottom = 12.0
+content_margin_left = 0.0
+content_margin_top = 0.0
+content_margin_right = 0.0
+content_margin_bottom = 0.0
 
 [node name="GameCard" type="PanelContainer"]
-custom_minimum_size = Vector2(0, 220)
+custom_minimum_size = Vector2(0, 260)
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_styles/panel = SubResource("card_style")
@@ -42,7 +42,8 @@ layout_mode = 2
 
 [node name="AccentBar" type="PanelContainer" parent="VBoxContainer"]
 layout_mode = 2
-custom_minimum_size = Vector2(0, 80)
+custom_minimum_size = Vector2(0, 160)
+size_flags_vertical = 3
 theme_override_styles/panel = SubResource("accent_style")
 
 [node name="PreviewContainer" type="SubViewportContainer" parent="VBoxContainer/AccentBar"]
@@ -56,7 +57,7 @@ visible = false
 [node name="PreviewViewport" type="SubViewport" parent="VBoxContainer/AccentBar/PreviewContainer"]
 unique_name_in_owner = true
 transparent_bg = true
-size = Vector2i(200, 200)
+size = Vector2i(320, 200)
 render_target_update_mode = 3
 
 [node name="Icon" type="TextureRect" parent="VBoxContainer/AccentBar"]

--- a/hub/game_card.tscn
+++ b/hub/game_card.tscn
@@ -22,12 +22,17 @@ shadow_size = 4
 shadow_offset = Vector2(0, 2)
 
 [sub_resource type="StyleBoxFlat" id="accent_style"]
-bg_color = Color(0.3, 0.55, 0.9, 1.0)
+bg_color = Color(0.12, 0.14, 0.18, 1.0)
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 0
+border_color = Color(0.3, 0.55, 0.9, 1.0)
 corner_radius_top_left = 12
 corner_radius_top_right = 12
-content_margin_left = 0.0
-content_margin_top = 0.0
-content_margin_right = 0.0
+content_margin_left = 3.0
+content_margin_top = 3.0
+content_margin_right = 3.0
 content_margin_bottom = 0.0
 
 [node name="GameCard" type="PanelContainer"]
@@ -73,7 +78,7 @@ stretch_mode = 5
 layout_mode = 2
 theme_override_constants/margin_left = 12
 theme_override_constants/margin_right = 12
-theme_override_constants/margin_top = 8
+theme_override_constants/margin_top = 12
 theme_override_constants/margin_bottom = 4
 
 [node name="Labels" type="VBoxContainer" parent="VBoxContainer/ContentMargin"]
@@ -82,7 +87,7 @@ layout_mode = 2
 [node name="GameName" type="Label" parent="VBoxContainer/ContentMargin/Labels"]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_font_sizes/font_size = 18
+theme_override_font_sizes/font_size = 22
 theme_override_colors/font_color = Color(0.95, 0.95, 0.97, 1.0)
 horizontal_alignment = 1
 

--- a/hub/game_card.tscn
+++ b/hub/game_card.tscn
@@ -45,6 +45,20 @@ layout_mode = 2
 custom_minimum_size = Vector2(0, 80)
 theme_override_styles/panel = SubResource("accent_style")
 
+[node name="PreviewContainer" type="SubViewportContainer" parent="VBoxContainer/AccentBar"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+stretch = true
+visible = false
+
+[node name="PreviewViewport" type="SubViewport" parent="VBoxContainer/AccentBar/PreviewContainer"]
+unique_name_in_owner = true
+transparent_bg = true
+size = Vector2i(200, 200)
+render_target_update_mode = 3
+
 [node name="Icon" type="TextureRect" parent="VBoxContainer/AccentBar"]
 unique_name_in_owner = true
 layout_mode = 2


### PR DESCRIPTION
## Summary
- Each game card shows a live animated preview via SubViewport instead of a static icon
- Dodge preview: AI player dodging falling red blocks
- Snake preview: scripted snake moving and growing through shape tiers (scaled to 200x200)
- Falls back to static icon for games without `preview.tscn`
- SubViewport pauses rendering when card is scrolled off-screen

Closes #1

## Test plan
- [ ] Hub shows animated previews on both game cards
- [ ] Dodge preview: blue player dodges red falling blocks
- [ ] Snake preview: geometric snake moves, grows, and evolves
- [ ] Tapping a card still launches the game correctly
- [ ] Games without preview.tscn show static icon fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)